### PR TITLE
Remove Linuxism

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cd codehighlighter
 zip -r codehighlighter.oxt .


### PR DESCRIPTION
/bin/bash is a Linuxism.  On other OSes, bash may be located at a
different path, or not installed at all.  /bin/sh is correct on any Unix
system, and this script doesn't need any bash-specific features.