### PR TITLE
Dialog to select language and style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+codehighlighter.oxt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/codehighlighter/Addons.xcu
+++ b/codehighlighter/Addons.xcu
@@ -35,6 +35,20 @@
                         <value>AddLast</value>
                     </prop>
                     <node oor:name="MenuItems">
+                        <node oor:name="highlight_code" oor:op="replace">
+                            <prop oor:name="Context" oor:type="xs:string">
+                                <value>com.sun.star.text.TextDocument,com.sun.star.sdb.TextReportDesign,com.sun.star.text.WebDocument,com.sun.star.xforms.XMLFormDocument,com.sun.star.text.GlobalDocument,com.sun.star.sdb.FormDesign,com.sun.star.sheet.SpreadsheetDocument,com.sun.star.drawing.DrawingDocument,com.sun.star.presentation.PresentationDocument,com.sun.star.sdb.OfficeDatabaseDocument</value>
+                            </prop>
+                            <prop oor:name="Title" oor:type="xs:string">
+                                <value xml:lang="en">Highlight Code</value>
+                            </prop>
+                            <prop oor:name="URL" oor:type="xs:string">
+                                <value>vnd.sun.star.script:codehighlighter.oxt|python|highlight.py$create_dialog?language=Python&amp;location=user:uno_packages</value>
+                            </prop>
+                            <prop oor:name="Target" oor:type="xs:string">
+                                <value>_self</value>
+                            </prop>
+                        </node>
                         <node oor:name="codehighlighter_menu" oor:op="replace">
                             <prop oor:name="Target" oor:type="xs:string">
                                 <value>_self</value>
@@ -43,8 +57,8 @@
                                 <value>com.sun.star.text.TextDocument,com.sun.star.sdb.TextReportDesign,com.sun.star.text.WebDocument,com.sun.star.xforms.XMLFormDocument,com.sun.star.text.GlobalDocument,com.sun.star.sdb.FormDesign,com.sun.star.sheet.SpreadsheetDocument,com.sun.star.drawing.DrawingDocument,com.sun.star.presentation.PresentationDocument,com.sun.star.sdb.OfficeDatabaseDocument</value>
                             </prop>
                             <prop oor:name="Title" oor:type="xs:string">
-                                <value xml:lang="en-US">Highlight Code</value>
-                                <value>Highlight Code</value>
+                                <value xml:lang="en-US">Highlight Code (default style)</value>
+                                <value>Highlight Code (default style)</value>
                             </prop>
                             <node oor:name="Submenu">
                                 <node oor:name="lang_0" oor:op="replace">

--- a/codehighlighter/description.xml
+++ b/codehighlighter/description.xml
@@ -3,7 +3,7 @@
   xmlns:d = "http://openoffice.org/extensions/description/2006"             
   xmlns:l = "http://libreoffice.org/extensions/description/2011" 
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <version value="1.5"/>
+  <version value="1.6"/>
   <identifier value="javahelps.codehighlighter"/>
   <icon>
     <default xlink:href="images/icon_48.png" />

--- a/codehighlighter/dialogs/CodeHighlighter.xdl
+++ b/codehighlighter/dialogs/CodeHighlighter.xdl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dlg:window PUBLIC "-//OpenOffice.org//DTD OfficeDocument 1.0//EN" "dialog.dtd">
+<dlg:window xmlns:dlg="http://openoffice.org/2000/dialog" xmlns:script="http://openoffice.org/2000/script" dlg:id="CodeHighlighter" dlg:left="203" dlg:top="169" dlg:width="175" dlg:height="148" dlg:closeable="true" dlg:moveable="true">
+ <dlg:bulletinboard>
+  <dlg:text dlg:id="Label1" dlg:tab-index="2" dlg:left="20" dlg:top="6" dlg:width="60" dlg:height="10" dlg:value="Language"/>
+  <dlg:text dlg:id="Label2" dlg:tab-index="3" dlg:left="20" dlg:top="60" dlg:width="60" dlg:height="10" dlg:value="Style"/>
+  <dlg:button dlg:id="CommandButton1" dlg:tab-index="4" dlg:left="102" dlg:top="125" dlg:width="52" dlg:height="16" dlg:value="OK" dlg:button-type="ok"/>
+  <dlg:button dlg:id="CommandButton2" dlg:tab-index="5" dlg:left="20" dlg:top="125" dlg:width="52" dlg:height="16" dlg:value="Cancel" dlg:button-type="cancel"/>
+  <dlg:combobox dlg:id="cb_lang" dlg:tab-index="0" dlg:left="20" dlg:top="24" dlg:width="100" dlg:height="12" dlg:spin="true"/>
+  <dlg:combobox dlg:id="cb_style" dlg:tab-index="1" dlg:left="20" dlg:top="78" dlg:width="100" dlg:height="12" dlg:spin="true"/>
+ </dlg:bulletinboard>
+</dlg:window>

--- a/codehighlighter/dialogs/CodeHighlighter.xdl
+++ b/codehighlighter/dialogs/CodeHighlighter.xdl
@@ -2,11 +2,19 @@
 <!DOCTYPE dlg:window PUBLIC "-//OpenOffice.org//DTD OfficeDocument 1.0//EN" "dialog.dtd">
 <dlg:window xmlns:dlg="http://openoffice.org/2000/dialog" xmlns:script="http://openoffice.org/2000/script" dlg:id="CodeHighlighter" dlg:left="203" dlg:top="169" dlg:width="175" dlg:height="148" dlg:closeable="true" dlg:moveable="true">
  <dlg:bulletinboard>
-  <dlg:text dlg:id="Label1" dlg:tab-index="2" dlg:left="20" dlg:top="6" dlg:width="60" dlg:height="10" dlg:value="Language"/>
-  <dlg:text dlg:id="Label2" dlg:tab-index="3" dlg:left="20" dlg:top="60" dlg:width="60" dlg:height="10" dlg:value="Style"/>
+  <dlg:text dlg:id="Label1" dlg:tab-index="2" dlg:left="20" dlg:top="6" dlg:width="60" dlg:height="10" dlg:value="Language">
+   <script:event script:event-name="on-keydown" script:macro-name="vnd.sun.star.script:codehighlighter.oxt|python|highlight.py$key_pressed?language=Python&amp;location=user:uno_packages" script:language="Script"/>
+  </dlg:text>
+  <dlg:text dlg:id="Label2" dlg:tab-index="3" dlg:left="20" dlg:top="60" dlg:width="60" dlg:height="10" dlg:value="Style">
+   <script:event script:event-name="on-keydown" script:macro-name="vnd.sun.star.script:codehighlighter.oxt|python|highlight.py$key_pressed?language=Python&amp;location=user:uno_packages" script:language="Script"/>
+  </dlg:text>
   <dlg:button dlg:id="CommandButton1" dlg:tab-index="4" dlg:left="102" dlg:top="125" dlg:width="52" dlg:height="16" dlg:value="OK" dlg:button-type="ok"/>
   <dlg:button dlg:id="CommandButton2" dlg:tab-index="5" dlg:left="20" dlg:top="125" dlg:width="52" dlg:height="16" dlg:value="Cancel" dlg:button-type="cancel"/>
-  <dlg:combobox dlg:id="cb_lang" dlg:tab-index="0" dlg:left="20" dlg:top="24" dlg:width="100" dlg:height="12" dlg:spin="true"/>
-  <dlg:combobox dlg:id="cb_style" dlg:tab-index="1" dlg:left="20" dlg:top="78" dlg:width="100" dlg:height="12" dlg:spin="true"/>
+  <dlg:combobox dlg:id="cb_lang" dlg:tab-index="0" dlg:left="20" dlg:top="24" dlg:width="100" dlg:height="12" dlg:spin="true">
+   <script:event script:event-name="on-keydown" script:macro-name="vnd.sun.star.script:codehighlighter.oxt|python|highlight.py$key_pressed?language=Python&amp;location=user:uno_packages" script:language="Script"/>
+  </dlg:combobox>
+  <dlg:combobox dlg:id="cb_style" dlg:tab-index="1" dlg:left="20" dlg:top="78" dlg:width="100" dlg:height="12" dlg:spin="true">
+   <script:event script:event-name="on-keydown" script:macro-name="vnd.sun.star.script:codehighlighter.oxt|python|highlight.py$key_pressed?language=Python&amp;location=user:uno_packages" script:language="Script"/>
+  </dlg:combobox>
  </dlg:bulletinboard>
 </dlg:window>

--- a/codehighlighter/python/highlight.py
+++ b/codehighlighter/python/highlight.py
@@ -44,7 +44,12 @@ def log(msg):
         text_file.write(str(msg) + "\r\n\r\n")
 
 def create_dialog():
+    # get_all_lexers() returns:
+    # (longname, tuple of aliases, tuple of filename patterns, tuple of mimetypes)
     all_lexers = [lex[0] for lex in get_all_lexers()]
+    all_lexer_aliases = [lex[0] for lex in get_all_lexers()]
+    for lex in get_all_lexers():
+        all_lexer_aliases.extend(list(lex[1]))
     all_styles = list(get_all_styles())
 
     ctx = uno.getComponentContext()
@@ -74,7 +79,7 @@ def create_dialog():
     style = cb_style.Text
     if lang == 'automatic':
         lang = None
-    assert lang == None or (lang in all_lexers), 'no valid language: ' + lang
+    assert lang == None or (lang in all_lexer_aliases), 'no valid language: ' + lang
     assert style in all_styles, 'no valid style: ' + style
 
     highlightSourceCode(lang, style)

--- a/codehighlighter/python/highlight.py
+++ b/codehighlighter/python/highlight.py
@@ -23,6 +23,7 @@ from pygments.lexers import get_all_lexers
 from pygments.lexers import get_lexer_by_name
 from pygments.lexers import guess_lexer
 from pygments.styles import get_all_styles
+import pygments.util
 import os
 
 
@@ -124,7 +125,17 @@ def highlight_code(code, cursor, lang, style):
     if lang is None:
         lexer = guess_lexer(code)
     else:
-        lexer = get_lexer_by_name(lang)
+        try:
+            lexer = get_lexer_by_name(lang)
+        except pygments.util.ClassNotFound:
+            # get_lexer_by_name() only checks aliases, not the actual longname
+            for lex in get_all_lexers():
+                if lex[0] == lang:
+                    # found the longname, use the first alias
+                    lexer = get_lexer_by_name(lex[1][0])
+                    break
+            else:
+                raise
     style = styles.get_style_by_name(style)
     for tok_type, tok_value in lexer.get_tokens(code):
         cursor.goRight(len(tok_value), True)  # selects the token's text

--- a/codehighlighter/python/highlight.py
+++ b/codehighlighter/python/highlight.py
@@ -79,6 +79,12 @@ def create_dialog():
 
     highlightSourceCode(lang, style)
 
+def key_pressed(event):
+    if event.KeyCode == 1280:
+        # enter
+        dialog = event.Source.getContext()
+        dialog.endDialog(1)
+
 def highlightSourceCode(lang, style):
     ctx = XSCRIPTCONTEXT
     doc = ctx.getDocument()

--- a/codehighlighter/python/highlight.py
+++ b/codehighlighter/python/highlight.py
@@ -16,7 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import uno
+
 from pygments import styles
+from pygments.lexers import get_all_lexers
 from pygments.lexers import get_lexer_by_name
 from pygments.lexers import guess_lexer
 from pygments.styles import get_all_styles
@@ -40,6 +43,41 @@ def log(msg):
     with open("/tmp/code-highlighter.log", "a") as text_file:
         text_file.write(str(msg) + "\r\n\r\n")
 
+def create_dialog():
+    all_lexers = [lex[0] for lex in get_all_lexers()]
+    all_styles = list(get_all_styles())
+
+    ctx = uno.getComponentContext()
+    smgr = ctx.ServiceManager
+    dialog_provider = smgr.createInstance("com.sun.star.awt.DialogProvider")
+    dialog = dialog_provider.createDialog("vnd.sun.star.extension://javahelps.codehighlighter/dialogs/CodeHighlighter.xdl")
+
+    cb_lang = dialog.getControl('cb_lang')
+    cb_style = dialog.getControl('cb_style')
+
+    cb_lang.addItem('automatic', 0)
+    cb_lang.Text = 'automatic'
+    for i, lex in enumerate(all_lexers):
+        cb_lang.addItem(lex, i+1)
+
+    if 'default' in all_styles:
+        cb_style.Text = 'default'
+    for i, style in enumerate(all_styles):
+        cb_style.addItem(style, i)
+
+    dialog.setVisible(True)
+    # 0: canceled, 1: OK
+    if dialog.execute() == 0:
+        return
+
+    lang = cb_lang.Text
+    style = cb_style.Text
+    if lang == 'automatic':
+        lang = None
+    assert lang == None or (lang in all_lexers), 'no valid language: ' + lang
+    assert style in all_styles, 'no valid style: ' + style
+
+    highlightSourceCode(lang, style)
 
 def highlightSourceCode(lang, style):
     ctx = XSCRIPTCONTEXT


### PR DESCRIPTION
This
- allows to select any style provided by pygments
- adds a dialog to select language and style

The sub-menus have been removed and only one field is used in the tools menu now:

![2019-08-19-153408_3840x1200_scrot](https://user-images.githubusercontent.com/6584443/63271167-d45a8e00-c299-11e9-84b6-c36be984ba86.png)

![2019-08-19-153441_3840x1200_scrot](https://user-images.githubusercontent.com/6584443/63271232-fa802e00-c299-11e9-9c91-b3859f3d27b2.png)


Closes #22, closes #36